### PR TITLE
Added support for 'B' bytes unit to parse_size

### DIFF
--- a/humanfriendly.py
+++ b/humanfriendly.py
@@ -16,7 +16,8 @@ import sys
 import time
 
 # Common disk size units, used for formatting and parsing.
-disk_size_units = (dict(prefix='k', divider=1024**1, singular='KB', plural='KB'),
+disk_size_units = (dict(prefix='b', divider=1, singular='byte', plural='bytes'),
+                   dict(prefix='k', divider=1024**1, singular='KB', plural='KB'),
                    dict(prefix='m', divider=1024**2, singular='MB', plural='MB'),
                    dict(prefix='g', divider=1024**3, singular='GB', plural='GB'),
                    dict(prefix='t', divider=1024**4, singular='TB', plural='TB'),

--- a/humanfriendly_tests.py
+++ b/humanfriendly_tests.py
@@ -63,7 +63,9 @@ class HumanFriendlyTestCase(unittest.TestCase):
         self.assertEqual('1 PB', humanfriendly.format_size(1024 ** 5))
 
     def test_parse_size(self):
+        self.assertEqual(0, humanfriendly.parse_size('0B'))
         self.assertEqual(42, humanfriendly.parse_size('42'))
+        self.assertEqual(42, humanfriendly.parse_size('42B'))
         self.assertEqual(1024, humanfriendly.parse_size('1k'))
         self.assertEqual(1024, humanfriendly.parse_size('1 KB'))
         self.assertEqual(1024, humanfriendly.parse_size('1 kilobyte'))


### PR DESCRIPTION
This library couldn't parse something like `14B` or `0B`, so I added support and tests to do so.

In particular, the `ls` command on OS X emits sizes like `0B` instead of the Linuxy `ls` which outputs just 0. Your library is great for parsing outputs like that and this fixes that corner case.

Thanks!
