### PR TITLE
Allow correct behavior of 'parse_size' and 'format_size'

### DIFF
--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -4,7 +4,7 @@
 # Tests for the `humanfriendly' package.
 #
 # Author: Peter Odding <peter.odding@paylogic.eu>
-# Last Change: April 21, 2016
+# Last Change: June 29, 2016
 # URL: https://humanfriendly.readthedocs.org
 
 """Test suite for the `humanfriendly` package."""
@@ -180,6 +180,10 @@ class HumanFriendlyTestCase(unittest.TestCase):
         self.assertEqual('1 GB', humanfriendly.format_size(1024 ** 3))
         self.assertEqual('1 TB', humanfriendly.format_size(1024 ** 4))
         self.assertEqual('1 PB', humanfriendly.format_size(1024 ** 5))
+        self.assertEqual('1 byte', humanfriendly.format_size(1, correct=True))
+        self.assertEqual('45 KB', humanfriendly.format_size(1000 * 45, correct=True))
+        self.assertEqual('1 GB', humanfriendly.format_size(1000 ** 3, correct=True))
+        self.assertEqual('2.9 TB', humanfriendly.format_size(1000 ** 4 * 2.9, correct=True))
 
     def test_parse_size(self):
         """Test :func:`humanfriendly.parse_size()`."""
@@ -193,6 +197,8 @@ class HumanFriendlyTestCase(unittest.TestCase):
         self.assertEqual(1024 ** 3 * 1.5, humanfriendly.parse_size('1.5 GB'))
         self.assertRaises(humanfriendly.InvalidSize, humanfriendly.parse_size, '1z')
         self.assertRaises(humanfriendly.InvalidSize, humanfriendly.parse_size, 'a')
+        self.assertEqual(1000, humanfriendly.parse_size('1 KB', correct=True))
+        self.assertEqual(1000 ** 2 * 69, humanfriendly.parse_size('69 MB', correct=True))
 
     def test_format_length(self):
         """Test :func:`humanfriendly.format_length()`."""


### PR DESCRIPTION
Maintain default behavior (for semantic versioning), but provide an option for people who want file sizes handled in base 10 instead of base 2. Would require a minor version bump.