### PR TITLE
Support min, mins abbreviations for minutes

### DIFF
--- a/humanfriendly/__init__.py
+++ b/humanfriendly/__init__.py
@@ -72,13 +72,13 @@ length_size_units = (dict(prefix='nm', divider=1e-09, singular='nm', plural='nm'
                      dict(prefix='km', divider=1000, singular='km', plural='km'))
 
 # Common time units, used for formatting of time spans.
-time_units = (dict(divider=1e-3, singular='millisecond', plural='milliseconds', abbreviation='ms'),
-              dict(divider=1, singular='second', plural='seconds', abbreviation='s'),
-              dict(divider=60, singular='minute', plural='minutes', abbreviation='m'),
-              dict(divider=60 * 60, singular='hour', plural='hours', abbreviation='h'),
-              dict(divider=60 * 60 * 24, singular='day', plural='days', abbreviation='d'),
-              dict(divider=60 * 60 * 24 * 7, singular='week', plural='weeks', abbreviation='w'),
-              dict(divider=60 * 60 * 24 * 7 * 52, singular='year', plural='years', abbreviation='y'))
+time_units = (dict(divider=1e-3, singular='millisecond', plural='milliseconds', abbreviations=['ms']),
+              dict(divider=1, singular='second', plural='seconds', abbreviations=['s']),
+              dict(divider=60, singular='minute', plural='minutes', abbreviations=['m', 'mins', 'min']),
+              dict(divider=60 * 60, singular='hour', plural='hours', abbreviations=['h']),
+              dict(divider=60 * 60 * 24, singular='day', plural='days', abbreviations=['d']),
+              dict(divider=60 * 60 * 24 * 7, singular='week', plural='weeks', abbreviations=['w']),
+              dict(divider=60 * 60 * 24 * 7 * 52, singular='year', plural='years', abbreviations=['y']))
 
 
 def coerce_boolean(value):
@@ -445,7 +445,7 @@ def parse_timespan(timespan):
         if len(tokens) == 2 and is_string(tokens[1]):
             normalized_unit = tokens[1].lower()
             for unit in time_units:
-                if normalized_unit in (unit['singular'], unit['plural'], unit['abbreviation']):
+                if normalized_unit in ([unit['singular'], unit['plural']] + unit['abbreviations']):
                     return float(tokens[0]) * unit['divider']
     # We failed to parse the timespan specification.
     msg = "Failed to parse timespan! (input %r was tokenized as %r)"

--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -168,6 +168,8 @@ class HumanFriendlyTestCase(unittest.TestCase):
         self.assertEqual(5, humanfriendly.parse_timespan('5 seconds'))
         self.assertEqual(60 * 2, humanfriendly.parse_timespan('2m'))
         self.assertEqual(60 * 2, humanfriendly.parse_timespan('2 minutes'))
+        self.assertEqual(60 * 3, humanfriendly.parse_timespan('3 min'))
+        self.assertEqual(60 * 3, humanfriendly.parse_timespan('3 mins'))
         self.assertEqual(60 * 60 * 3, humanfriendly.parse_timespan('3 h'))
         self.assertEqual(60 * 60 * 3, humanfriendly.parse_timespan('3 hours'))
         self.assertEqual(60 * 60 * 24 * 4, humanfriendly.parse_timespan('4d'))


### PR DESCRIPTION
# Problem
I've been very happy with the `parse_timespan` functionality of humanfriendly. The only issue I've had is that sometimes I'd like to say "3 min" or "3 mins" for minutes.

# Solution
I've changed `time_units` to allow for multiple abbreviations per time unit. I also changed `parse_timespan` to look through all abbreviations when parsing times. Finally, I added "min" and "mins" as abbreviations for minutes.

# Outcome
Parsing "3 min" and "3 mins" is now supported!