### PR TITLE
Include docs to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst
 include *.txt
+graft docs


### PR DESCRIPTION
Same rationales as for `coloredlogs` and `verboselogs`