### PR TITLE
Fix ImportError exception on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ docs/_static/
 docs/_templates/
 docs/build/
 htmlcov/
+*.pyc
+__pycache__/
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,11 @@ def get_install_requires():
             install_requires.extend(('importlib', 'unittest2'))
         if sys.version_info[:2] < (3, 3):
             install_requires.append('monotonic')
+    if sys.platform == 'win32':
+        # GNU Readline is not present on Windows, which causes humanfriendly
+        # to raise an ImportError at runtime.
+        # pyreadline is a pure-python alternative that solves this issue
+        install_requires.extend('pyreadline')
     return sorted(install_requires)
 
 


### PR DESCRIPTION
Adding pyreadline as a requirement for Windows fixes the ImportError that occurs where ever readline is used. ( Issue #19 )