### PR TITLE
Fixed bug in `parse_length` that rounded floats

### DIFF
--- a/humanfriendly/__init__.py
+++ b/humanfriendly/__init__.py
@@ -290,7 +290,7 @@ def parse_length(length):
     if tokens and isinstance(tokens[0], numbers.Number):
         # If the input contains only a number, it's assumed to be the number of metres.
         if len(tokens) == 1:
-            return int(tokens[0])
+            return tokens[0]
         # Otherwise we expect to find two tokens: A number and a unit.
         if len(tokens) == 2 and is_string(tokens[1]):
             normalized_unit = tokens[1].lower()

--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -381,6 +381,7 @@ class HumanFriendlyTestCase(TestCase):
         """Test :func:`humanfriendly.parse_length()`."""
         self.assertEqual(0, humanfriendly.parse_length('0m'))
         self.assertEqual(42, humanfriendly.parse_length('42'))
+        self.assertEqual(1.5, humanfriendly.parse_length('1.5'))
         self.assertEqual(42, humanfriendly.parse_length('42m'))
         self.assertEqual(1000, humanfriendly.parse_length('1km'))
         self.assertEqual(0.153, humanfriendly.parse_length('15.3 cm'))


### PR DESCRIPTION
Previously, `humanfriendly.parse_length('1.5') == 1`. This fixes that by removing an unnecessary `int`. 