### PR TITLE
Pluralize singular fix

### DIFF
--- a/humanfriendly/__init__.py
+++ b/humanfriendly/__init__.py
@@ -391,7 +391,7 @@ def round_number(count, keep_width=False):
     text = '%.2f' % float(count)
     if not keep_width:
         text = re.sub('0+$', '', text)
-        text = re.sub('\.$', '', text)
+        text = re.sub(r'\.$', '', text)
     return text
 
 

--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -257,6 +257,9 @@ class HumanFriendlyTestCase(TestCase):
         self.assertEqual('2 words', humanfriendly.pluralize(2, 'word'))
         self.assertEqual('1 box', humanfriendly.pluralize(1, 'box', 'boxes'))
         self.assertEqual('2 boxes', humanfriendly.pluralize(2, 'box', 'boxes'))
+        self.assertEqual('0.5 seconds', humanfriendly.pluralize(0.5, 'second'))
+        self.assertEqual('1.0 second', humanfriendly.pluralize(1.0, 'second'))
+        self.assertEqual('1.62 seconds', humanfriendly.pluralize(1.62, 'second'))
 
     def test_boolean_coercion(self):
         """Test :func:`humanfriendly.coerce_boolean()`."""
@@ -311,7 +314,7 @@ class HumanFriendlyTestCase(TestCase):
         # Make sure milliseconds are never shown separately when detailed=False.
         # https://github.com/xolox/python-humanfriendly/issues/10
         assert '1 minute, 1 second and 100 milliseconds' == humanfriendly.format_timespan(61.10, detailed=True)
-        assert '1 minute and 1.1 second' == humanfriendly.format_timespan(61.10, detailed=False)
+        assert '1 minute and 1.1 seconds' == humanfriendly.format_timespan(61.10, detailed=False)
         # Test for loss of precision as reported in issue 11:
         # https://github.com/xolox/python-humanfriendly/issues/11
         assert '1 minute and 0.3 seconds' == humanfriendly.format_timespan(60.300)

--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -557,7 +557,7 @@ class HumanFriendlyTestCase(TestCase):
         # Generate a table with column names.
         column_names = ['One', 'Two', 'Three']
         data = [['1', '2', '3'], ['a', 'b', 'c']]
-        self.assertEquals(
+        self.assertEqual(
             format_rst_table(data, column_names),
             dedent("""
                 ===  ===  =====
@@ -570,7 +570,7 @@ class HumanFriendlyTestCase(TestCase):
         )
         # Generate a table without column names.
         data = [['1', '2', '3'], ['a', 'b', 'c']]
-        self.assertEquals(
+        self.assertEqual(
             format_rst_table(data),
             dedent("""
                 =  =  =

--- a/humanfriendly/text.py
+++ b/humanfriendly/text.py
@@ -20,7 +20,6 @@ The :mod:`~humanfriendly.text` module contains simple functions to manipulate te
 """
 
 # Standard library modules.
-import math
 import numbers
 import random
 import re
@@ -266,7 +265,7 @@ def pluralize(count, singular, plural=None):
     """
     if not plural:
         plural = singular + 's'
-    return '%s %s' % (count, singular if math.floor(float(count)) == 1 else plural)
+    return '%s %s' % (count, singular if float(count) == 1.0 else plural)
 
 
 def random_string(length=(25, 100), characters=string.ascii_letters):


### PR DESCRIPTION
Pluralize should only use singular if count is exactly 1, as e.g. `1.63 second` and `0.5 second` are grammatically incorrect.