### PR TITLE
Add support for nanoseconds and microseconds time units

### DIFF
--- a/humanfriendly/__init__.py
+++ b/humanfriendly/__init__.py
@@ -77,7 +77,9 @@ length_size_units = (dict(prefix='nm', divider=1e-09, singular='nm', plural='nm'
                      dict(prefix='km', divider=1000, singular='km', plural='km'))
 
 # Common time units, used for formatting of time spans.
-time_units = (dict(divider=1e-3, singular='millisecond', plural='milliseconds', abbreviations=['ms']),
+time_units = (dict(divider=1e-9, singular='nanosecond', plural='nanoseconds', abbreviations=['ns']),
+              dict(divider=1e-6, singular='microsecond', plural='microseconds', abbreviations=['us']),
+              dict(divider=1e-3, singular='millisecond', plural='milliseconds', abbreviations=['ms']),
               dict(divider=1, singular='second', plural='seconds', abbreviations=['s', 'sec', 'secs']),
               dict(divider=60, singular='minute', plural='minutes', abbreviations=['m', 'min', 'mins']),
               dict(divider=60 * 60, singular='hour', plural='hours', abbreviations=['h']),
@@ -432,7 +434,7 @@ def format_timespan(num_seconds, detailed=False, max_units=3):
         # Slow path.
         result = []
         num_seconds = decimal.Decimal(str(num_seconds))
-        relevant_units = list(reversed(time_units[0 if detailed else 1:]))
+        relevant_units = list(reversed(time_units[0 if detailed else 3:]))
         for unit in relevant_units:
             # Extract the unit count from the remaining time.
             divider = decimal.Decimal(str(unit['divider']))

--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -296,6 +296,10 @@ class HumanFriendlyTestCase(TestCase):
         day = hour * 24
         week = day * 7
         year = week * 52
+        assert '1 nanosecond' == humanfriendly.format_timespan(0.000000001, detailed=True)
+        assert '500 nanoseconds' == humanfriendly.format_timespan(0.0000005, detailed=True)
+        assert '1 microsecond' == humanfriendly.format_timespan(0.000001, detailed=True)
+        assert '500 microseconds' == humanfriendly.format_timespan(0.0005, detailed=True)
         assert '1 millisecond' == humanfriendly.format_timespan(0.001, detailed=True)
         assert '500 milliseconds' == humanfriendly.format_timespan(0.5, detailed=True)
         assert '0.5 seconds' == humanfriendly.format_timespan(0.5, detailed=False)
@@ -328,6 +332,7 @@ class HumanFriendlyTestCase(TestCase):
         assert '5 minutes and 0.3 seconds' == humanfriendly.format_timespan(300.300)
         assert '1 second and 15 milliseconds' == humanfriendly.format_timespan(1.015, detailed=True)
         assert '10 seconds and 15 milliseconds' == humanfriendly.format_timespan(10.015, detailed=True)
+        assert '1 microsecond and 50 nanoseconds' == humanfriendly.format_timespan(0.00000105, detailed=True)
         # Test the datetime.timedelta support:
         # https://github.com/xolox/python-humanfriendly/issues/27
         now = datetime.datetime.now()
@@ -338,6 +343,10 @@ class HumanFriendlyTestCase(TestCase):
         """Test :func:`humanfriendly.parse_timespan()`."""
         self.assertEqual(0, humanfriendly.parse_timespan('0'))
         self.assertEqual(0, humanfriendly.parse_timespan('0s'))
+        self.assertEqual(0.000000001, humanfriendly.parse_timespan('1ns'))
+        self.assertEqual(0.000000051, humanfriendly.parse_timespan('51ns'))
+        self.assertEqual(0.000001, humanfriendly.parse_timespan('1us'))
+        self.assertEqual(0.000052, humanfriendly.parse_timespan('52us'))
         self.assertEqual(0.001, humanfriendly.parse_timespan('1ms'))
         self.assertEqual(0.001, humanfriendly.parse_timespan('1 millisecond'))
         self.assertEqual(0.5, humanfriendly.parse_timespan('500 milliseconds'))


### PR DESCRIPTION
This is useful for benchmarking where timings are smaller than milliseconds.