### PR TITLE
skip pyreadline dependency on Windows with Python 3.9+

### DIFF
--- a/humanfriendly/prompts.py
+++ b/humanfriendly/prompts.py
@@ -341,7 +341,11 @@ def prepare_friendly_prompts():
     This function is called by the other functions in this module to enable
     user friendly prompts.
     """
-    import readline  # NOQA
+    try:
+        import readline  # NOQA
+    except ImportError:
+        # might not be available on Windows if pyreadline isn't installed
+        pass
 
 
 def retry_limit(limit=MAX_ATTEMPTS):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ def get_install_requires():
         if sys.version_info.major == 2:
             install_requires.append('monotonic')
         if sys.platform == 'win32':
-            install_requires.append('pyreadline')
+            # pyreadline isn't compatible with Python 3.9+
+            # https://github.com/pyreadline/pyreadline/issues/65
+            install_requires.append('pyreadline ; python_version<"3.9"')
     return sorted(install_requires)
 
 
@@ -63,7 +65,9 @@ def get_extras_require():
         ])
         extras_require[expression] = ['monotonic']
         # Conditional `pyreadline' dependency.
-        expression = ':sys_platform == "win32"'
+        # pyreadline isn't compatible with Python 3.9+
+        # https://github.com/pyreadline/pyreadline/issues/65
+        expression = ':sys_platform == "win32" and python_version<"3.9"'
         extras_require[expression] = 'pyreadline'
     return extras_require
 


### PR DESCRIPTION
Fixes #44 

Since `pyreadline` doesn't support Python 3.9 and isn't being maintained at the moment this patch makes the dependency conditional based on the Python version. Additionally the import of the module is allowed to fail.