### PR TITLE
Declare support for and test Python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   - python: 3.6
   - python: 3.7
   - python: 3.8
-  - python: 3.9-dev
+  - python: 3.9
 install:
   - scripts/travis.sh pip install --upgrade setuptools
   - scripts/travis.sh pip install --upgrade --requirement=requirements-travis.txt

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Communications',


### PR DESCRIPTION
Python 3.9 was officially released in October 2020.