### PR TITLE
Fix CI

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 # Test suite requirements.
 capturer >= 2.1
-coloredlogs >= 2.0
+coloredlogs >= 2.0, <= 14.0
 docutils >= 0.15
 mock >= 3.0.5
 pytest >= 3.0.7

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,5 @@
 --requirement=requirements-checks.txt
 --requirement=requirements-tests.txt
 coveralls
+# Dependency of coveralls:
+cryptography < 3; python_version == '2.7' and platform_python_implementation == "PyPy"


### PR DESCRIPTION
Some time between [1 December](https://travis-ci.org/github/xolox/python-humanfriendly/builds/746870367) and [10 December](https://travis-ci.org/github/xolox/python-humanfriendly/builds/748661340) `test_prompt_for_confirmation` started failing on the CI:

```
        # Test that the default reply is shown in uppercase.
        with PatchedAttribute(prompts, 'interactive_prompt', lambda p: 'y'):
            for default_value, expected_text in (True, 'Y/n'), (False, 'y/N'), (None, 'y/n'):
                with CaptureOutput(merged=True) as capturer:
                    assert prompt_for_confirmation("Are you sure?", default=default_value) is True
>                   assert expected_text in capturer.get_text()
E                   AssertionError: assert 'Y/n' in '\n'
E                    +  where '\n' = <bound method CaptureOutput.get_text of <humanfriendly.testing.CaptureOutput object at 0x7f4e25f69a90>>()
E                    +    where <bound method CaptureOutput.get_text of <humanfriendly.testing.CaptureOutput object at 0x7f4e25f69a90>> = <humanfriendly.testing.CaptureOutput object at 0x7f4e25f69a90>.get_text
```

The same failure happens if I try the older commit which worked before: 44cbc418c4b53c06ad5428d225254590e4e68aff.

Checking the changed dependencies between those two and through a process of trial and error, it passes with `coloredlogs==14.0` and fails with `coloredlogs==14.1`.

Here's a diff of those releases: https://github.com/xolox/python-coloredlogs/compare/14.0...14.1

In the meantime, let's pin.
