### PR TITLE
Declare plugin is compatible with parallel reading

### DIFF
--- a/humanfriendly/sphinx.py
+++ b/humanfriendly/sphinx.py
@@ -250,7 +250,7 @@ def setup(app):
     enable_pypi_role(app)
     enable_special_methods(app)
     enable_usage_formatting(app)
-    
+
     return {
         "parallel_read_safe": True,
     }

--- a/humanfriendly/sphinx.py
+++ b/humanfriendly/sphinx.py
@@ -250,6 +250,10 @@ def setup(app):
     enable_pypi_role(app)
     enable_special_methods(app)
     enable_usage_formatting(app)
+    
+    return {
+        "parallel_read_safe": True,
+    }
 
 
 def special_methods_callback(app, what, name, obj, skip, options):


### PR DESCRIPTION
I'm getting a warning from this plugin, which is problematic because I want to treat warnings as errors: 

> the humanfriendly.sphinx extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit

See https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata

`parallel_write_safe` can be omitted (tested locally).
