### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
         os: [ubuntu-latest]
         include:
           - { python-version: "3.7", os: macos-latest }

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Communications',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pypy
+envlist = py27, py35, py36, py37, py38, py39, py310, pypy
 
 [testenv]
 deps = -rrequirements-tests.txt


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955