### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,9 @@ setup(
     description="Human friendly output for text interfaces using Python",
     long_description=get_contents('README.rst'),
     url='https://humanfriendly.readthedocs.io',
+    project_urls={
+        'Source': 'https://github.com/xolox/python-humanfriendly',
+    },
     author="Peter Odding",
     author_email='peter@peterodding.com',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     long_description=get_contents('README.rst'),
     url='https://humanfriendly.readthedocs.io',
     project_urls={
-        'Source': 'https://github.com/xolox/python-humanfriendly',
+        'Source': 'https://github.com/alteryx/featuretools',
     },
     author="Peter Odding",
     author_email='peter@peterodding.com',

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     long_description=get_contents('README.rst'),
     url='https://humanfriendly.readthedocs.io',
     project_urls={
-        'Source': 'https://github.com/alteryx/featuretools',
+        'Source': 'https://github.com/xolox/python-humanfriendly',
     },
     author="Peter Odding",
     author_email='peter@peterodding.com',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.