### PR TITLE
Do not import setup in the tests module

### DIFF
--- a/humanfriendly/tests.py
+++ b/humanfriendly/tests.py
@@ -59,7 +59,7 @@ from humanfriendly.sphinx import (
     deprecation_note_callback,
     man_role,
     pypi_role,
-    setup,
+    setup as sphinx_setup,
     special_methods_callback,
     usage_message_callback,
 )
@@ -1444,7 +1444,7 @@ class HumanFriendlyTestCase(TestCase):
 
         # Test event callback registration.
         fake_app = FakeApp()
-        setup(fake_app)
+        sphinx_setup(fake_app)
         assert man_role == fake_app.roles['man']
         assert pypi_role == fake_app.roles['pypi']
         assert deprecation_note_callback in fake_app.callbacks['autodoc-process-docstring']


### PR DESCRIPTION
pytest 7 and above will call any setup as a hook for any module
collected, which in this case calls into the Sphinx machinery due to
importing the setup function from there. Import it as something else so
that pytest will not call it.

Fixes #64