### PR TITLE
Super simple error fix : ansi style code 39 instead of 48 for background

### DIFF
--- a/humanfriendly/terminal/__init__.py
+++ b/humanfriendly/terminal/__init__.py
@@ -236,7 +236,7 @@ def ansi_style(**kw):
         elif isinstance(color_value, numbers.Number):
             # Numeric values are assumed to be 256 color codes.
             sequences.extend((
-                39 if color_type == 'background' else 38,
+                48 if color_type == 'background' else 38,
                 5, int(color_value)
             ))
         elif color_value:


### PR DESCRIPTION
Tested and working on my windows 10 computer.

The right code for ansi background color is **48**, not **39**. ([link to the problematic line](https://github.com/xolox/python-humanfriendly/blob/6758ac61f906cd8528682003070a57febe4ad3cf/humanfriendly/terminal/__init__.py#L239C18-L239C18))
The error was specific when supplying only one numeric value for background color.
It was not the case for tuples of 3 numeric values (RGB) as [48 code was already correctly specified for this case](https://github.com/xolox/python-humanfriendly/blob/6758ac61f906cd8528682003070a57febe4ad3cf/humanfriendly/terminal/__init__.py#L233C17-L233C17).