### PR TITLE
Replace pipes.quote with shlex.quote on Python 3

### DIFF
--- a/humanfriendly/cli.py
+++ b/humanfriendly/cli.py
@@ -79,9 +79,13 @@ Supported options:
 # Standard library modules.
 import functools
 import getopt
-import pipes
 import subprocess
 import sys
+
+try:
+    from shlex import quote  # Python 3
+except ImportError:
+    from pipes import quote  # Python 2 (removed in 3.13)
 
 # Modules included in our package.
 from humanfriendly import (
@@ -176,7 +180,7 @@ def main():
 def run_command(command_line):
     """Run an external command and show a spinner while the command is running."""
     timer = Timer()
-    spinner_label = "Waiting for command: %s" % " ".join(map(pipes.quote, command_line))
+    spinner_label = "Waiting for command: %s" % " ".join(map(quote, command_line))
     with Spinner(label=spinner_label, timer=timer) as spinner:
         process = subprocess.Popen(command_line)
         while True:

--- a/humanfriendly/testing.py
+++ b/humanfriendly/testing.py
@@ -25,12 +25,16 @@ its much better error reporting) but I've yet to publish a test suite that
 import functools
 import logging
 import os
-import pipes
 import shutil
 import sys
 import tempfile
 import time
 import unittest
+
+try:
+    from shlex import quote  # Python 3
+except ImportError:
+    from pipes import quote  # Python 2 (removed in 3.13)
 
 # Modules included in our package.
 from humanfriendly.compat import StringIO
@@ -521,7 +525,7 @@ class MockedProgram(CustomSearchPath):
         pathname = os.path.join(directory, self.program_name)
         with open(pathname, 'w') as handle:
             handle.write('#!/bin/sh\n')
-            handle.write('echo > %s\n' % pipes.quote(self.program_signal_file))
+            handle.write('echo > %s\n' % quote(self.program_signal_file))
             if self.program_script:
                 handle.write('%s\n' % self.program_script.strip())
             handle.write('exit %i\n' % self.program_returncode)


### PR DESCRIPTION
The `shlex.quote()` API is available from Python 3.3 on; `pipes.quote()` was never documented, and is removed in Python 3.13.

Fixes #73.